### PR TITLE
Fix couple of compiler warnings

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -37,10 +37,10 @@ b64_to_bin(unsigned char * const bin, const char *b64,
         return NULL;
     }
     while (i-- > 0U) {
-        t0 = rev64chars[*b64++];
-        t1 = rev64chars[*b64++];
-        t2 = rev64chars[*b64++];
-        t3 = rev64chars[*b64++];
+        t0 = rev64chars[*b64_u++];
+        t1 = rev64chars[*b64_u++];
+        t2 = rev64chars[*b64_u++];
+        t3 = rev64chars[*b64_u++];
         t = t3 | ((uint32_t) t2 << 6) | ((uint32_t) t1 << 12) |
             ((uint32_t) t0 << 18);
         mask = t0 | t1 | t2 | t3;

--- a/src/minisign.c
+++ b/src/minisign.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 
 #include <assert.h>
 #include <getopt.h>


### PR DESCRIPTION
With these two patches, minisign compiles clean without zero warnings. (Debian Sid/amd64)