### PR TITLE
Use the DIR_SEP macro to remove an ifdef.

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -170,14 +170,9 @@ file_basename(const char *file)
 {
     char *ptr;
 
-    if ((ptr = strrchr(file, '/')) != NULL) {
+    if ((ptr = strrchr(file, DIR_SEP)) != NULL) {
         return ptr + 1;
     }
-#ifdef _WIN32
-    if ((ptr = strrchr(file, '\\')) != NULL) {
-        return ptr + 1;
-    }
-#endif
     return file;
 }
 


### PR DESCRIPTION
helpers.h already defines DIR_SEP, so use it to make this function slightly nicer to read.