### PR TITLE
Add interactive (-i) switch

### DIFF
--- a/src/minisign.c
+++ b/src/minisign.c
@@ -369,7 +369,8 @@ seckey_load(const char *sk_file)
          seckey_struct->kdf_salt,
          le64_load(seckey_struct->kdf_opslimit_le),
          le64_load(seckey_struct->kdf_memlimit_le)) != 0) {
-        exit_err("Unable to complete key derivation - This probably means out of memory");
+        puts("failed");
+        exit_err("Unable to complete key derivation");
     }
     sodium_free(pwd);
     xor_buf((unsigned char *) (void *) &seckey_struct->keynum_sk, stream,
@@ -669,7 +670,8 @@ generate(const char *pk_file, const char *sk_file, const char *comment,
          seckey_struct->kdf_salt,
          le64_load(seckey_struct->kdf_opslimit_le),
          le64_load(seckey_struct->kdf_memlimit_le)) != 0) {
-        exit_err("Unable to complete key derivation - This probably means out of memory");
+        puts("failed");
+        exit_err("Unable to complete key derivation");
     }
     sodium_free(pwd);
     sodium_free(pwd2);


### PR DESCRIPTION
Having encountered a problem with a low-memory box I added the -i switch so that I can use the tool.
It's based on [Issue 62: Aborted (core dumped) when crypto_pwhash_scryptsalsa208sha256() returns -1](https://github.com/jedisct1/minisign/issues/62)

I realize I could use a laptop instead but if you think this still makes sense and is safe feel free to review.
