### PR TITLE
Add Ubuntu PPA package

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Minisign is also available in chocolatey on Windows:
 
     $ choco install minisign
 
+Minisign is also available on Ubuntu as a PPA:
+
+    $ [sudo] add-apt-repository ppa:dysfunctionalprogramming/minisign
+
 Additional tools, libraries and implementations
 -----------------------------------------------
 


### PR DESCRIPTION
Hello! I am a minisign and Ubuntu user and maintain a personal package archive (PPA) that other Ubuntu users can use to easily and quickly install it.

The package source is here: https://github.com/dysfunctionalprogramming/minisign, with the PPA landing page here: https://launchpad.net/~dysfunctionalprogramming/+archive/ubuntu/minisign.

The PPA will be actively maintained and currently supports the latest LTS release (18.04) as well as the last two non-LTS releases, 19.04 and 19.10 (actually due to be released later this month).

This pull request is to add this to the list of packages that are available, if you so wish.