### PR TITLE
Move '..' to end in README static binaries example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Compilation:
 
 Alternative configuration for static binaries:
 
-    $ cmake .. -D STATIC_LIBSODIUM=1
+    $ cmake -D STATIC_LIBSODIUM=1 ..
 
 or:
 
-    $ cmake .. -D BUILD_STATIC_EXECUTABLES=1
+    $ cmake -D BUILD_STATIC_EXECUTABLES=1 ..
 
 Minisign is also available in Homebrew:
 


### PR DESCRIPTION
I've had cmake error out on me with:
```
CMake Error: The source directory "... /build/STATIC_LIBSODIUM=1" does not exist
```
when following the README for building static binaries.

Following the synopsis from [cmake(1)](https://cmake.org/cmake/help/latest/manual/cmake.1.html) and moving the path-to-source to the end might save others some confusion.