### PR TITLE
Fix example of how to verify with pubkey

### DIFF
--- a/share/man/man1/minisign.1
+++ b/share/man/man1/minisign.1
@@ -123,7 +123,7 @@ The secret key is loaded from \fB${MINISIGN_CONFIG_DIR}/minisign\.key\fR, \fB~/\
 Verifying a file
 .
 .P
-$ \fBminisign\fR \-Vm myfile\.txt \-p <pubkey>
+$ \fBminisign\fR \-Vm myfile\.txt \-P <pubkey>
 .
 .P
 or

--- a/src/manpage.md
+++ b/src/manpage.md
@@ -81,7 +81,7 @@ The secret key is loaded from `${MINISIGN_CONFIG_DIR}/minisign.key`, `~/.minisig
 
 Verifying a file
 
-$ `minisign` -Vm myfile.txt -p  &lt;pubkey&gt;
+$ `minisign` -Vm myfile.txt -P  &lt;pubkey&gt;
 
 or
 


### PR DESCRIPTION
Hi.

This commit corrects the example showing how to verify a file with a `pubkey`, i.e. the public key supplied in the command line rather than by `.pub` file, bu using the `-P` option.

Regards,
Sakib