### PR TITLE
Action to identify keys used in various file types

### DIFF
--- a/src/minisign.h
+++ b/src/minisign.h
@@ -58,6 +58,7 @@ typedef enum Action_ {
     ACTION_GENERATE,
     ACTION_SIGN,
     ACTION_VERIFY,
+    ACTION_IDENTIFY,
     ACTION_RECREATE_PK
 } Action;
 


### PR DESCRIPTION
Please be aware that I am not very good at "C", and most of this was derived by just composing copypasta bits from various places within minisign, so it might deserve an extra bit of scrutiny.

If there are significant changes required, I would humbly ask for help making them (or simply for the maintainers to reimplement it as would be acceptable), as this took me a while to compose and C is really NOT by strong suite.

Usage example:
```
$ mkdir tmp

$ ./zig-out/bin/minisign -G -p tmp/pub -s tmp/sec
[...snip...]
Files signed using this key pair can be verified with the following command:

minisign -Vm <file> -P RWSHRgUst0bdZ+XN6Hc50aJCf5AZUFtIjjEvpWyCDzjqXFpBGIE3VMdQ

$ echo body > tmp/message.txt

$ ./zig-out/bin/minisign -Sm tmp/message.txt -s tmp/sec
[...snip...]

$ ./zig-out/bin/minisign -k -m tmp/message.txt
67DD46B72C054687

$ ./zig-out/bin/minisign -k -x tmp/message.txt.minisig 
67DD46B72C054687

$ ./zig-out/bin/minisign -k -P RWSHRgUst0bdZ+XN6Hc50aJCf5AZUFtIjjEvpWyCDzjqXFpBGIE3VMdQ
67DD46B72C054687

$ ./zig-out/bin/minisign -k -p tmp/pub
67DD46B72C054687

$ ./zig-out/bin/minisign -k -s tmp/sec
Password: (empty)
Deriving a key from the password and decrypting the secret key... 
done

67DD46B72C054687
```
