### PR TITLE
Replacing " ' " with "." to meet Debian packaging policies

### DIFF
--- a/share/man/man1/minisign.1
+++ b/share/man/man1/minisign.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "MINISIGN" "1" "October 2021" "" ""
+.TH "MINISIGN" "1" "June 2020" "" ""
 .
 .SH "NAME"
 \fBminisign\fR \- A dead simple tool to sign files and verify signatures\.
@@ -48,6 +48,10 @@ File to sign/verify
 Combined with \-V, output the file content after verification
 .
 .TP
+\fB\-H\fR
+Combined with \-S, pre\-hash in order to sign large files
+.
+.TP
 \fB\-p <pubkeyfile>\fR
 Public key file (default: \./minisign\.pub)
 .
@@ -72,16 +76,8 @@ Add a one\-line untrusted comment
 Add a one\-line trusted comment
 .
 .TP
-\fB\-l\fR
-Sign using the legacy format
-.
-.TP
 \fB\-q\fR
 Quiet mode, suppress output
-.
-.TP
-\fB\-H\fR
-Requires the input to be prehashed
 .
 .TP
 \fB\-Q\fR
@@ -118,7 +114,7 @@ $ \fBminisign\fR \-Sm myfile\.txt $ \fBminisign\fR \-Sm myfile\.txt myfile2\.txt
 Or to include a comment in the signature, that will be verified and displayed when verifying the file:
 .
 .P
-$ \fBminisign\fR \-Sm myfile\.txt \-t \'This comment will be signed as well\'
+$ \fBminisign\fR \-Sm myfile\.txt \-t \.This comment will be signed as well\.
 .
 .P
 The secret key is loaded from \fB${MINISIGN_CONFIG_DIR}/minisign\.key\fR, \fB~/\.minisign/minisign\.key\fR, or its path can be explicitly set with the \fB\-s <path>\fR command\-line switch\.
@@ -142,6 +138,9 @@ This requires the signature \fBmyfile\.txt\.minisig\fR to be present in the same
 The public key can either reside in a file (\fB\./minisign\.pub\fR by default) or be directly specified on the command line\.
 .
 .SH "Notes"
+\fBTrusted comments\fR
+.
+.P
 Signature files include an untrusted comment line that can be freely modified, even after signature creation\.
 .
 .P
@@ -149,6 +148,42 @@ They also include a second comment line, that cannot be modified without the sec
 .
 .P
 Trusted comments can be used to add instructions or application\-specific metadata (intended file name, timestamps, resource identifiers, version numbers to prevent downgrade attacks)\.
+.
+.P
+\fBCompatibility with OpenBSD signify\fR
+.
+.P
+Signatures written by \fBminisign\fR can be verified using OpenBSD\.s \fBsignify\fR tool: public key files and signature files are compatible\.
+.
+.P
+However, \fBminisign\fR uses a slightly different format to store secret keys\.
+.
+.P
+\fBMinisign\fR signatures include trusted comments in addition to untrusted comments\. Trusted comments are signed, thus verified, before being displayed\.
+.
+.P
+This adds two lines to the signature files, that signify silently ignores\.
+.
+.P
+\fBPre\-hashing\fR
+.
+.P
+By default, signing and verification require as much memory as the size of the file\.
+.
+.P
+Since \fBMinisign 0\.6\fR, huge files can be signed and verified with very low memory requirements, by pre\-hashing the content\.
+.
+.P
+The \-H command\-line switch, in combination with \-S, generates a pre\-hashed signature (HashEdDSA):
+.
+.P
+$ \fBminisign\fR \-SHm myfile\.txt
+.
+.P
+Verification of such a signature doesn\.t require any specific switch: the appropriate algorithm will automatically be detected\.
+.
+.P
+Signatures generated that way are not compatible with OpenBSD\.s \fBsignify\fR tool and are not compatible with \fBMinisign\fR versions prior to 0\.6\.
 .
 .SH "AUTHOR"
 Frank Denis (github [at] pureftpd [dot] org)


### PR DESCRIPTION
Hi !
This program is being packaged to be part of the official Debian repositories.

The purpose of which was to replace the " ' " with the " ." in the manual.

This is part of Debian's packaging policy.

However I realized that the manual that is in version 0.10 is different from the one in the repository.

the 0.10 lines have a " ' " in lines: 117, 156, 183 and 186.