### PR TITLE
Update `build.zig` to be compatible with zig 0.10.0+

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,13 +9,13 @@ pub fn build(b: *std.build.Builder) !void {
     minisign.setBuildMode(mode);
     minisign.install();
     minisign.linkLibC();
-    minisign.addLibPath("/opt/homebrew/lib");
-    minisign.addLibPath("/usr/local/lib");
+    minisign.addLibraryPath("/opt/homebrew/lib");
+    minisign.addLibraryPath("/usr/local/lib");
     minisign.linkSystemLibrary("sodium");
 
-    minisign.addIncludeDir("src");
-    minisign.addSystemIncludeDir("/opt/homebrew/include");
-    minisign.addSystemIncludeDir("/usr/local/include");
+    minisign.addIncludePath("src");
+    minisign.addSystemIncludePath("/opt/homebrew/include");
+    minisign.addSystemIncludePath("/usr/local/include");
     minisign.defineCMacro("_GNU_SOURCE", "1");
     minisign.addCSourceFiles(&.{ "src/base64.c", "src/get_line.c", "src/helpers.c", "src/minisign.c" }, &.{});
 }


### PR DESCRIPTION
Please check https://github.com/ziglang/zig/blob/1ec74f1b70607a17829277e846ea19be6aed1fc1/lib/std/build/LibExeObjStep.zig#L916