### PR TITLE
Add support for passing the key password non-interactively

### DIFF
--- a/src/get_line.c
+++ b/src/get_line.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
@@ -109,10 +110,22 @@ get_password(char *pwd, size_t max_len, const char *prompt)
 {
     int ret;
 
-    disable_echo();
-    ret = get_line(pwd, max_len, prompt);
-    enable_echo();
-
+    char* env_var_pwd = getenv("MINISIGN_PASSWORD");
+    if (env_var_pwd != NULL) {
+        size_t env_var_pwd_len = strlen(env_var_pwd);
+        if (env_var_pwd_len >= max_len) {
+            fprintf(stderr, "MINISIGN_PASSWORD environment variable value\
+               exceeds maximum allowed length\n");
+            return -1;
+        } else {
+            strcpy(pwd, env_var_pwd);
+            return 0;
+        }
+    } else {
+        disable_echo();
+        ret = get_line(pwd, max_len, prompt);
+        enable_echo();
+    }
     return ret;
 }
 


### PR DESCRIPTION
Right now the only way to sign something with a password-protected key is to enter the key password via stdin. That is inconvenient for use in scripts and CI pipelines.

This PR adds support for passing the password in an environment variable called `MINISIGN_PASSWORD`.

I'm not claiming this design is actually good — it's more of a starting point for a discussion. I'm happy to change any details if you have different ideas.