### PR TITLE
build: fix mach-o relocation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,10 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
         .strip = true,
     });
+
+    // fix Mach-O relocation
+    minisign.headerpad_max_install_names = true;
+
     minisign.linkLibC();
     if (use_libzodium) {
         var libzodium = lib: {


### PR DESCRIPTION
seeing some mach-o relocation issue 

```
  ==> Bottling minisign--0.12.arm[64](https://github.com/chenrui333/homebrew-tap/actions/runs/13023588771/job/36328834223?pr=69#step:7:65)_sonoma.bottle.tar.gz...
  Error: Failed changing rpath in /opt/homebrew/Cellar/minisign/0.12/bin/minisign
    from /opt/homebrew/opt/libsodium/lib
      to @@HOMEBREW_PREFIX@@/opt/libsodium/lib
```

relates to https://github.com/ziglang/zig/issues/13388
verified in https://github.com/chenrui333/homebrew-tap/pull/69