### PR TITLE
Update required Zig version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Minisign is available in various package managers:
 **Dependencies:**
 
 - [libsodium](https://libsodium.org/) (optional)
-- [zig](https://ziglang.org) (version 0.14.0 or later)
+- [zig](https://ziglang.org) (version 0.15.1 or later)
 
 **Compilation options:**
 


### PR DESCRIPTION
As of 20ccc774085f3b865dd9c0b8fbc859bdaf8b1fa5, the minimum required Zig version is 0.15.1.